### PR TITLE
Added borough, district and team codes to endpoints as required. 

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/deliusWiremock/dao/entity/TeamEntity.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/deliusWiremock/dao/entity/TeamEntity.java
@@ -22,13 +22,18 @@ public class TeamEntity {
   @Id
   private Long id;
 
+  // PDU == borough
+  private String boroughCode;
+  private String boroughDescription;
+
+  // LAU == district
+  private String districtCode;
+  private String districtDescription;
+
+  // Team
   private String teamCode;
   private String teamDescription;
   private String teamTelephone;
-  private String lduCode;
-  private String lduDescription;
-  private String boroughCode;
-  private String boroughDescription;
 
   @ManyToMany
   @JoinTable(

--- a/src/main/java/uk/gov/justice/digital/hmpps/deliusWiremock/dto/response/TeamResponse.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/deliusWiremock/dto/response/TeamResponse.java
@@ -12,7 +12,7 @@ public class TeamResponse {
 
   String code;
   String description;
-  AreaResponse localDeliveryUnit;
   AreaResponse borough;
+  AreaResponse district;
   String telephone;
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/deliusWiremock/mapper/Mapper.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/deliusWiremock/mapper/Mapper.java
@@ -34,12 +34,12 @@ public class Mapper {
     propertyMapper.addMappings(mapper -> mapper.<String>map(StaffEntity::getProbationAreaDescription, (dest, v) -> dest.getProbationArea().setDescription(v)));
 
     TypeMap<TeamEntity, TeamResponse> teamMapper = modelMapper.createTypeMap(TeamEntity.class, TeamResponse.class);
-    teamMapper.addMappings(mapper -> mapper.map(TeamEntity::getTeamCode, TeamResponse::setCode));
-    teamMapper.addMappings(mapper -> mapper.map(TeamEntity::getTeamDescription, TeamResponse::setDescription));
-    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getLduCode, (dest, v) -> dest.getLocalDeliveryUnit().setCode(v)));
-    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getLduDescription, (dest, v) -> dest.getLocalDeliveryUnit().setDescription(v)));
     teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getBoroughCode, (dest, v) -> dest.getBorough().setCode(v)));
     teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getBoroughDescription, (dest, v) -> dest.getBorough().setDescription(v)));
+    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getDistrictCode, (dest, v) -> dest.getDistrict().setCode(v)));
+    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getDistrictDescription, (dest, v) -> dest.getDistrict().setDescription(v)));
+    teamMapper.addMappings(mapper -> mapper.map(TeamEntity::getTeamCode, TeamResponse::setCode));
+    teamMapper.addMappings(mapper -> mapper.map(TeamEntity::getTeamDescription, TeamResponse::setDescription));
 
     StaffDetailResponse result = modelMapper.map(staffEntity, StaffDetailResponse.class);
 
@@ -82,10 +82,14 @@ public class Mapper {
 
     TypeMap<OffenderEntity, CommunityOrPrisonOffenderManager> propertyMapper = modelMapper.createTypeMap(OffenderEntity.class, CommunityOrPrisonOffenderManager.class);
     propertyMapper.addMappings(mapper -> mapper.map(src -> src.getStaff().getStaffIdentifier(), CommunityOrPrisonOffenderManager::setStaffId));
-    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getBoroughCode(), (dest, v) -> dest.getProbationArea().setCode(v)));
-    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getBoroughDescription(), (dest, v) -> dest.getProbationArea().setDescription(v)));
-    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getLduCode(), (dest, v) -> dest.getTeam().getLocalDeliveryUnit().setCode(v)));
-    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getLduDescription(), (dest, v) -> dest.getTeam().getLocalDeliveryUnit().setDescription(v)));
+    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getStaff().getProbationAreaCode(), (dest, v) -> dest.getProbationArea().setCode(v)));
+    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getStaff().getProbationAreaDescription(), (dest, v) -> dest.getProbationArea().setDescription(v)));
+    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getTeamCode(), (dest, v) -> dest.getTeam().setCode(v)));
+    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getTeamDescription(), (dest, v) -> dest.getTeam().setDescription(v)));
+    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getBoroughCode(), (dest, v) -> dest.getTeam().getBorough().setCode(v)));
+    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getBoroughDescription(), (dest, v) -> dest.getTeam().getBorough().setDescription(v)));
+    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getDistrictCode(), (dest, v) -> dest.getTeam().getDistrict().setCode(v)));
+    propertyMapper.addMappings(mapper -> mapper.<String>map(src -> src.getTeam().getDistrictDescription(), (dest, v) -> dest.getTeam().getDistrict().setDescription(v)));
 
     return modelMapper.map(offenderEntity, CommunityOrPrisonOffenderManager.class);
   }
@@ -109,12 +113,10 @@ public class Mapper {
     TypeMap<TeamEntity, TeamResponse> teamMapper = modelMapper.createTypeMap(TeamEntity.class, TeamResponse.class);
     teamMapper.addMappings(mapper -> mapper.map(TeamEntity::getTeamCode, TeamResponse::setCode));
     teamMapper.addMappings(mapper -> mapper.map(TeamEntity::getTeamDescription, TeamResponse::setDescription));
-    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getLduCode, (dest, v) -> dest.getLocalDeliveryUnit().setCode(v)));
-    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getLduDescription, (dest, v) -> dest.getLocalDeliveryUnit().setDescription(v)));
-
-    TypeMap<TeamEntity, AreaResponse> areaMapper = modelMapper.createTypeMap(TeamEntity.class, AreaResponse.class);
-    areaMapper.addMappings(mapper -> mapper.map(TeamEntity::getLduCode, AreaResponse::setCode));
-    areaMapper.addMappings(mapper -> mapper.map(TeamEntity::getLduDescription, AreaResponse::setDescription));
+    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getBoroughCode, (dest, v) -> dest.getBorough().setCode(v)));
+    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getBoroughDescription, (dest, v) -> dest.getBorough().setDescription(v)));
+    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getDistrictCode, (dest, v) -> dest.getDistrict().setCode(v)));
+    teamMapper.addMappings(mapper -> mapper.<String>map(TeamEntity::getDistrictDescription, (dest, v) -> dest.getDistrict().setDescription(v)));
 
     ProbationerResponse result = modelMapper.map(offenderEntity, ProbationerResponse.class);
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,20 +1,20 @@
 -- TEAMS
-INSERT INTO team(id, team_code, team_description, team_telephone, ldu_code, ldu_description, borough_code, borough_description) VALUES
-(1, 'cvl', 'Licence Team', '0800001066', 'N55UNA', 'Nottingham City District', 'N55U', 'Nottingham'),
-(2, 'pb', 'Private Beta Testers', '0800001066', 'N55UNE', 'Nottingham City District', 'N55U', 'Nottingham');
+INSERT INTO team(id, team_code, team_description, team_telephone, borough_code, borough_description, district_code, district_description) VALUES
+(1, 'cvl', 'Licence Team', '0800001066', 'N55PDU', 'Nottingham', 'N55LAU', 'Nottingham South'),
+(2, 'pb', 'Private Beta Testers', '0800001066', 'N55PDU', 'Nottingham', 'N55LAU', 'Nottingham South');
 
 -- STAFF
 -- The below contact details are not real
 INSERT INTO staff(id, staff_identifier, username, staff_code, email, telephone_number, staff_forenames, staff_surname, probation_area_code, probation_area_description) VALUES
-(1, 1000, 'smcveigh2', 'X12340', 'smcveigh2@probation.gov.uk', '07786 989777', 'Stephen', 'McVeigh', 'N55', 'Yorkshire and Humber'),
-(2, 2000, 'timharrison', 'X12341', 'timharrison@probation.gov.uk', '07786 989777', 'Tim', 'Harrison', 'N55', 'Yorkshire and Humber'),
-(3, 3000, 'cvl_com', 'X12342', 'cvl_com@probation.gov.uk', '07786 989777', 'CVL', 'COM', 'N55', 'Yorkshire and Humber'),
-(4, 4000, 'kamsandhu', 'X12343', 'kamsandhu@probation.gov.uk', '07786 989777', 'Kam', 'Sandhu', 'N55', 'Yorkshire and Humber'),
-(5, 5000, 'santhosh', 'X12344', 'santhosh@probation.gov.uk', '07786 989777', 'Santhosh', 'Chinnathambi', 'N55', 'Yorkshire and Humber'),
-(6, 6000, 'jeddyshaw', 'X12345', 'jeddyshaw@probation.gov.uk', '07786 989777', 'Jonathan', 'Eddyshaw', 'N55', 'Yorkshire and Humber'),
-(7, 7000, 'AdamRichardson', 'X12346', 'adamrichardson@probation.gov.uk', '07786 989777', 'Adam', 'Richardson', 'N55', 'Yorkshire and Humber'),
-(8, 8000, 'Laura.Jara.Duncan', 'X12347', 'laura.jara.duncan@probation.gov.uk', '07786 989777', 'Laura', 'Jara Duncan', 'N55', 'Yorkshire and Humber'),
-(9, 9000, 'cvl_beta_dev', 'X12348', 'betatester1@probation.gov.uk', '07786 989777','John', 'Smith', 'N55', 'Yorkshire and Humber');
+(1, 1000, 'smcveigh2', 'X12340', 'smcveigh2@probation.gov.uk', '07786 989777', 'Stephen', 'McVeigh', 'N55', 'Midlands'),
+(2, 2000, 'timharrison', 'X12341', 'timharrison@probation.gov.uk', '07786 989777', 'Tim', 'Harrison', 'N55', 'Midlands'),
+(3, 3000, 'cvl_com', 'X12342', 'cvl_com@probation.gov.uk', '07786 989777', 'CVL', 'COM', 'N55', 'Midlands'),
+(4, 4000, 'kamsandhu', 'X12343', 'kamsandhu@probation.gov.uk', '07786 989777', 'Kam', 'Sandhu', 'N55', 'Midlands'),
+(5, 5000, 'santhosh', 'X12344', 'santhosh@probation.gov.uk', '07786 989777', 'Santhosh', 'Chinnathambi', 'N55', 'Midlands'),
+(6, 6000, 'jeddyshaw', 'X12345', 'jeddyshaw@probation.gov.uk', '07786 989777', 'Jonathan', 'Eddyshaw', 'N55', 'Midlands'),
+(7, 7000, 'AdamRichardson', 'X12346', 'adamrichardson@probation.gov.uk', '07786 989777', 'Adam', 'Richardson', 'N55', 'Midlands'),
+(8, 8000, 'Laura.Jara.Duncan', 'X12347', 'laura.jara.duncan@probation.gov.uk', '07786 989777', 'Laura', 'Jara Duncan', 'N55', 'Midlands'),
+(9, 9000, 'cvl_beta_dev', 'X12348', 'betatester1@probation.gov.uk', '07786 989777','John', 'Smith', 'N55', 'Midlands');
 
 -- TEAM-STAFF MAP
 INSERT INTO staff_team(staff_id, team_id) VALUES


### PR DESCRIPTION
Responses for each endpoint have been checked with a full run-through of create / approve / view / print and caseload views locally.